### PR TITLE
Fix typo

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1301,7 +1301,7 @@ BrowserFSConfigure().then(() => {
                 'You can also open directories (it\'s just iframe with files served from browserfs using service worker).',
                 'If you have web app you can open it using file browser and [[;#fff;]view] command.',
                 '',
-                'You can use [[;#fff;]record start] to record commands in url hash so you can share commansds you\'ll type.',
+                'You can use [[;#fff;]record start] to record commands in url hash so you can share commands you\'ll type.',
                 ''
             ].join('\n'), {keepWords: true});
         }


### PR DESCRIPTION
Hi @jcubic,

I was trying out your git terminal hoping to find ways my own usage of isomorphic-git could be sped up, and this caught my eye:

![image](https://user-images.githubusercontent.com/1559108/192123780-254bd6bf-0506-4e92-89b7-2cefd91de6b3.png)

Now it's fixed.

(I would prefer not to be added to the contributors list for removing one letter.)